### PR TITLE
homework(module-03/lesson-07): Dmitry Timchuk

### DIFF
--- a/homeworks/dtimchuk/module-3/lesson-07/app-configmap-v2.yaml
+++ b/homeworks/dtimchuk/module-3/lesson-07/app-configmap-v2.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: course-app-config
+  namespace: dtimchuk-dev
+  labels:
+    app: course-app
+    env: development
+data:
+  APP_NAME: "Course Application Updated"
+  APP_VERSION: "2.0"
+  APP_ENVIRONMENT: "development"
+  LOG_LEVEL: "debug"
+  MESSAGE: "Hello from ConfigMap version 2 - UPDATED!"

--- a/homeworks/dtimchuk/module-3/lesson-07/app-configmap.yaml
+++ b/homeworks/dtimchuk/module-3/lesson-07/app-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: course-app-config
+  namespace: dtimchuk-dev
+  labels:
+    app: course-app
+    env: development
+data:
+  APP_NAME: "Course Application"
+  APP_VERSION: "1.0"
+  APP_ENVIRONMENT: "development"
+  LOG_LEVEL: "info"
+  MESSAGE: "Hello from ConfigMap version 1"

--- a/homeworks/dtimchuk/module-3/lesson-07/app-deployment-fast.yaml
+++ b/homeworks/dtimchuk/module-3/lesson-07/app-deployment-fast.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: course-app
+  namespace: dtimchuk-dev
+  labels:
+    app: course-app
+    env: development
+spec:
+  replicas: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Fast update with temporary overload of resources
+      maxUnavailable: 5  # could be unavailable 5 pods (50%) => 10 total pods
+      maxSurge: 5        # could be created 5 additional pods (50%) => 15 total pods
+  selector:
+    matchLabels:
+      app: course-app
+  template:
+    metadata:
+      labels:
+        app: course-app
+        env: development
+    spec:
+      containers:
+      - name: course-app
+        image: dmitrytimchuk/course-app:latest
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: APP_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_NAME
+        - name: APP_VERSION
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_VERSION
+        - name: APP_ENVIRONMENT
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_ENVIRONMENT
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: LOG_LEVEL
+        - name: MESSAGE
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: MESSAGE

--- a/homeworks/dtimchuk/module-3/lesson-07/app-deployment-no-surge.yaml
+++ b/homeworks/dtimchuk/module-3/lesson-07/app-deployment-no-surge.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: course-app
+  namespace: dtimchuk-dev
+  labels:
+    app: course-app
+    env: development
+spec:
+  replicas: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Strategy without additional resources: no surge, only replacements
+      maxUnavailable: 3  # can delete 3 pods at a time
+      maxSurge: 0        # save resources by not creating new pods
+  selector:
+    matchLabels:
+      app: course-app
+  template:
+    metadata:
+      labels:
+        app: course-app
+        env: development
+    spec:
+      containers:
+      - name: course-app
+        image: dmitrytimchuk/course-app:latest
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: APP_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_NAME
+        - name: APP_VERSION
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_VERSION
+        - name: APP_ENVIRONMENT
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_ENVIRONMENT
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: LOG_LEVEL
+        - name: MESSAGE
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: MESSAGE

--- a/homeworks/dtimchuk/module-3/lesson-07/app-deployment-recreate.yaml
+++ b/homeworks/dtimchuk/module-3/lesson-07/app-deployment-recreate.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: course-app
+  namespace: dtimchuk-dev
+  labels:
+    app: course-app
+    env: development
+spec:
+  replicas: 10
+  strategy:
+    type: Recreate
+    # Recreate strategy: delete all pods first, then create new === downtime
+  selector:
+    matchLabels:
+      app: course-app
+  template:
+    metadata:
+      labels:
+        app: course-app
+        env: development
+    spec:
+      containers:
+      - name: course-app
+        image: dmitrytimchuk/course-app:latest
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: APP_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_NAME
+        - name: APP_VERSION
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_VERSION
+        - name: APP_ENVIRONMENT
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_ENVIRONMENT
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: LOG_LEVEL
+        - name: MESSAGE
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: MESSAGE

--- a/homeworks/dtimchuk/module-3/lesson-07/app-deployment-slow.yaml
+++ b/homeworks/dtimchuk/module-3/lesson-07/app-deployment-slow.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: course-app
+  namespace: dtimchuk-dev
+  labels:
+    app: course-app
+    env: development
+spec:
+  replicas: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Slow update with max availability
+      maxUnavailable: 0  # Set up new pods only when old ones are finished
+      maxSurge: 2        # Max 2 additional pods
+  selector:
+    matchLabels:
+      app: course-app
+  template:
+    metadata:
+      labels:
+        app: course-app
+        env: development
+    spec:
+      containers:
+      - name: course-app
+        image: dmitrytimchuk/course-app:latest
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: APP_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_NAME
+        - name: APP_VERSION
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_VERSION
+        - name: APP_ENVIRONMENT
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_ENVIRONMENT
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: LOG_LEVEL
+        - name: MESSAGE
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: MESSAGE

--- a/homeworks/dtimchuk/module-3/lesson-07/app-deployment.yaml
+++ b/homeworks/dtimchuk/module-3/lesson-07/app-deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: course-app
+  namespace: dtimchuk-dev
+  labels:
+    app: course-app
+    env: development
+spec:
+  replicas: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: course-app
+  template:
+    metadata:
+      labels:
+        app: course-app
+        env: development
+    spec:
+      containers:
+      - name: course-app
+        image: dmitrytimchuk/course-app:latest
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: APP_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_NAME
+        - name: APP_VERSION
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_VERSION
+        - name: APP_ENVIRONMENT
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: APP_ENVIRONMENT
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: LOG_LEVEL
+        - name: MESSAGE
+          valueFrom:
+            configMapKeyRef:
+              name: course-app-config
+              key: MESSAGE

--- a/homeworks/dtimchuk/module-3/lesson-07/app-service.yaml
+++ b/homeworks/dtimchuk/module-3/lesson-07/app-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: course-app
+  namespace: dtimchuk-dev
+  labels:
+    app: course-app
+    env: development
+spec:
+  type: NodePort
+  ports:
+  - port: 8080
+    targetPort: 8080
+    nodePort: 30080
+    protocol: TCP
+    name: http
+  selector:
+    app: course-app

--- a/homeworks/dtimchuk/module-3/lesson-07/namespace.yaml
+++ b/homeworks/dtimchuk/module-3/lesson-07/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dtimchuk-dev
+  labels:
+    env: development
+    owner: dtimchuk


### PR DESCRIPTION
# Homework 7: Pod, Deployment, ReplicaSet

### Main files:
- `namespace.yaml` - Kubernetes namespace for isolation resources
- `app-configmap.yaml` - ConfigMap with variables for the application
- `app-deployment.yaml` - Base Deployment with 10 replicas and default RollingUpdate strategy
- `app-service.yaml` - Service for access to the application

### Additional files for deployment strategies (testing purposes):
- `app-deployment-fast.yaml` - "Fast" RollingUpdate strategy (fast update 50% of pods 10/5/5 -> maxUnavailable: 5 (could be unavailable 5 pods) + maxSurge: 5 (pods could be additionally created))
- `app-deployment-slow.yaml` - "Slow" RollingUpdate strategy (0 unavailable pods with 2 additional pods -> maxUnavailable: 0 + maxSurge: 2)
- `app-deployment-recreate.yaml` - Recreate strategy (replace all pods at the same time)
- `app-deployment-no-surge.yaml` - Strategy without additional resources: no surge, only replacements

---

## Test 1: Deployment with 10 replicas

### Commands to create resources:

```bash
# 1. Create namespace
kubectl apply -f namespace.yaml

# 2. Create ConfigMap
kubectl apply -f app-configmap.yaml

# 3. Deploy Deployment
kubectl apply -f app-deployment.yaml

# 4. Deploy Service
kubectl apply -f app-service.yaml
```

### Перевірка:

```bash
# Check pods amount
kubectl get pods -n dtimchuk-dev

# Verify details Deployment
kubectl get deployment course-app -n dtimchuk-dev

# Verify ReplicaSet
kubectl get replicaset -n dtimchuk-dev

# Detail info about Deployment
kubectl describe deployment course-app -n dtimchuk-dev

dtimchuk@dt lesson-07 % kubectl describe deployment -n dtimchuk-dev
Name:                   course-app
Namespace:              dtimchuk-dev
CreationTimestamp:      Wed, 19 Nov 2025 21:42:25 +0100
Labels:                 app=course-app
                        env=development
Annotations:            deployment.kubernetes.io/revision: 1
Selector:               app=course-app
Replicas:               10 desired | 10 updated | 10 total | 10 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  1 max unavailable, 1 max surge
Pod Template:
  Labels:  app=course-app
           env=development
  Containers:
   course-app:
    Image:      dmitrytimchuk/course-app:latest
    Port:       8080/TCP
    Host Port:  0/TCP
    Environment:
      APP_NAME:         <set to the key 'APP_NAME' of config map 'course-app-config'>         Optional: false
      APP_VERSION:      <set to the key 'APP_VERSION' of config map 'course-app-config'>      Optional: false
      APP_ENVIRONMENT:  <set to the key 'APP_ENVIRONMENT' of config map 'course-app-config'>  Optional: false
      LOG_LEVEL:        <set to the key 'LOG_LEVEL' of config map 'course-app-config'>        Optional: false
      MESSAGE:          <set to the key 'MESSAGE' of config map 'course-app-config'>          Optional: false
    Mounts:             <none>
  Volumes:              <none>
  Node-Selectors:       <none>
  Tolerations:          <none>
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable
OldReplicaSets:  <none>
NewReplicaSet:   course-app-b88795cf8 (10/10 replicas created)
Events:
  Type    Reason             Age   From                   Message
  ----    ------             ----  ----                   -------
  Normal  ScalingReplicaSet  2m3s  deployment-controller  Scaled up replica set course-app-b88795cf8 from 0 to 10

dtimchuk@dt lesson-07 % kubectl get replicaset -n dtimchuk-dev     
NAME                   DESIRED   CURRENT   READY   AGE
course-app-b88795cf8   10        10        10      3m43s
```


---

## Test 2: Replace ConfigMap and check updated Pods

ConfigMap використовується через змінні оточення (`env`). Kubernetes НЕ автоматично перезапускає поди при зміні ConfigMap через `env`.

### Update ConfigMap
```bash
kubectl apply -f app-configmap-v2.yaml
```

### Перевірка оновлення:

```bash
# 1. Check current ConfigMap
kubectl get configmap course-app-config -n dtimchuk-dev -o yaml

dtimchuk@dt lesson-07 % kubectl get configmap course-app-config -n dtimchuk-dev -o yaml
apiVersion: v1
data:
  APP_ENVIRONMENT: development
  APP_NAME: Course Application Updated
  APP_VERSION: "2.0"
  LOG_LEVEL: debug
  MESSAGE: Hello from ConfigMap version 2 - UPDATED!
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"APP_ENVIRONMENT":"development","APP_NAME":"Course Application Updated","APP_VERSION":"2.0","LOG_LEVEL":"debug","MESSAGE":"Hello from ConfigMap version 2 - UPDATED!"},"kind":"ConfigMap","metadata":{"annotations":{},"labels":{"app":"course-app","env":"development"},"name":"course-app-config","namespace":"dtimchuk-dev"}}
  creationTimestamp: "2025-11-19T20:42:19Z"
  labels:
    app: course-app
    env: development
  name: course-app-config
  namespace: dtimchuk-dev
  resourceVersion: "160288"
  uid: 2f4fbbdb-43a7-4fba-985b-4c102b00a0c5

# 2. Check variables in pod
kubectl exec -n dtimchuk-dev <pod-name> -- env | grep MESSAGE

dtimchuk@dt lesson-07 % kubectl get pods -n dtimchuk-dev
NAME                         READY   STATUS    RESTARTS   AGE
course-app-b88795cf8-29rxn   1/1     Running   0          6m38s
course-app-b88795cf8-4btdc   1/1     Running   0          6m38s
course-app-b88795cf8-4vc85   1/1     Running   0          6m38s
course-app-b88795cf8-fltq9   1/1     Running   0          6m38s
course-app-b88795cf8-jxp6v   1/1     Running   0          6m38s
course-app-b88795cf8-lhqkx   1/1     Running   0          6m38s
course-app-b88795cf8-n9xf4   1/1     Running   0          6m38s
course-app-b88795cf8-s8hdt   1/1     Running   0          6m38s
course-app-b88795cf8-tq5cf   1/1     Running   0          6m38s
course-app-b88795cf8-v8tnm   1/1     Running   0          6m38s

dtimchuk@dt lesson-07 % kubectl exec -n dtimchuk-dev course-app-b88795cf8-29rxn -- env | grep MESSAGE
MESSAGE=Hello from ConfigMap version 1

# 3. Pods NOT updated yet!
# To see new variables, we should restart Deployment:
kubectl rollout restart deployment course-app -n dtimchuk-dev

# 4. Спостерігати за процесом оновлення
kubectl rollout status deployment course-app -n dtimchuk-dev

dtimchuk@dt DOCKER-AND-KUBERNETES-KLYMENOK-1 % kubectl rollout status deployment course-app -n dtimchuk-dev
Waiting for deployment "course-app" rollout to finish: 4 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 4 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 4 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 5 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 5 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 5 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 5 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 5 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 6 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 6 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 6 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 6 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 6 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 7 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 7 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 7 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 7 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 8 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 8 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 8 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 8 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 8 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 9 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 9 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 9 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 9 out of 10 new replicas have been updated...
Waiting for deployment "course-app" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "course-app" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "course-app" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "course-app" rollout to finish: 9 of 10 updated replicas are available...
deployment "course-app" successfully rolled out

# 5. Check new variables in pod
kubectl exec -n dtimchuk-dev <new-pod-name> -- env | grep MESSAGE

dtimchuk@dt DOCKER-AND-KUBERNETES-KLYMENOK-1 % kubectl get pods -n dtimchuk-dev                            
NAME                          READY   STATUS    RESTARTS   AGE
course-app-846446fcd4-4wz5k   1/1     Running   0          80s
course-app-846446fcd4-5wk6t   1/1     Running   0          82s
course-app-846446fcd4-7qwv8   1/1     Running   0          86s
course-app-846446fcd4-8tg9m   1/1     Running   0          84s
course-app-846446fcd4-bbrrv   1/1     Running   0          81s
course-app-846446fcd4-bjcxg   1/1     Running   0          83s
course-app-846446fcd4-jmrr4   1/1     Running   0          88s
course-app-846446fcd4-mrw77   1/1     Running   0          88s
course-app-846446fcd4-p8r2x   1/1     Running   0          79s
course-app-846446fcd4-z9r6b   1/1     Running   0          86s

dtimchuk@dt DOCKER-AND-KUBERNETES-KLYMENOK-1 % kubectl exec -n dtimchuk-dev course-app-846446fcd4-4wz5k -- env | grep MESSAGE
MESSAGE=Hello from ConfigMap version 2 - UPDATED!
```

### Важливі моменти:
- ConfigMap оновлюється миттєво
- Поди НЕ отримують нові значення автоматично при використанні `env`
- Потрібно перезапустити Deployment для застосування нових значень

---

## Test 3: Verify different strategies (fast / no-surge / recreate / slow)

### 3.1. Стандартна стратегія (app-deployment.yaml)

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 1  # Максимум 1 под може бути недоступний
    maxSurge: 1        # Максимум 1 додатковий под
```

**Тестування:**
```bash
kubectl apply -f app-deployment.yaml
kubectl set env deployment/course-app APP_VERSION="1.1" -n dtimchuk-dev
kubectl rollout status deployment course-app -n dtimchuk-dev

kubectl get pods -n dtimchuk-dev -w
```

**Спостереження:**
- Процес: Створити 1 новий → Видалити 1 старий → Повторити
- Кількість подів: 9-11 (10 ±1)
- Швидкість: Помірна
- Доступність: Мінімум 9/10 подів завжди працюють

---

### 3.2. Швидка стратегія (app-deployment-fast.yaml)

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 5  # 50% подів можуть бути недоступні
    maxSurge: 5        # Додатково 50% подів
```

**Тестування:**
```bash
kubectl delete deployment course-app -n dtimchuk-dev
kubectl apply -f app-deployment-fast.yaml
kubectl set env deployment/course-app APP_VERSION="2.0" -n dtimchuk-dev
kubectl rollout status deployment course-app -n dtimchuk-dev

kubectl get pods -n dtimchuk-dev -w
```

**Спостереження:**
- Процес: Створює 5 нових подів одночасно, видаляє 5 старих
- Кількість подів: 5-15 (значні коливання)
- Швидкість: Дуже швидка
- Доступність: Мінімум 5/10 подів (50%)

**Переваги:**
- Швидке оновлення
- Менше часу в змішаному стані (старі + нові поди)

**Недоліки:**
- Велике навантаження на кластер (до 15 подів)
- Ризик перевантаження при обмежених ресурсах
- Нижча доступність під час оновлення

---

### 3.3. Консервативна стратегія (app-deployment-slow.yaml)

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 0  # Жодного поду не можна видаляти
    maxSurge: 2        # Максимум 2 додаткових поди
```

**Тестування:**
```bash
kubectl delete deployment course-app -n dtimchuk-dev
kubectl apply -f app-deployment-slow.yaml
kubectl set env deployment/course-app APP_VERSION="3.0" -n dtimchuk-dev
kubectl rollout status deployment course-app -n dtimchuk-dev

kubectl get pods -n dtimchuk-dev -w
```

**Спостереження:**
- Процес: Спочатку створює 2 нових, потім видаляє 2 старих, повторює
- Кількість подів: 10-12 (стабільно)
- Швидкість: Повільна
- Доступність: Завжди мінімум 10/10 подів

**Переваги:**
- Максимальна доступність (100%)
- Безпечне оновлення
- Відсутність downtime

**Недоліки:**
- Повільне оновлення
- Потребує додаткових ресурсів (до 12 подів)
- Довший період змішаного стану

---

### 3.4. Без додаткових ресурсів (app-deployment-no-surge.yaml)

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 3  # До 3 подів можуть бути недоступні
    maxSurge: 0        # Немає додаткових подів
```

**Тестування:**
```bash
kubectl delete deployment course-app -n dtimchuk-dev
kubectl apply -f app-deployment-no-surge.yaml
kubectl set env deployment/course-app APP_VERSION="4.0" -n dtimchuk-dev
kubectl get pods -n dtimchuk-dev -w
```

**Спостереження:**
- Процес: Видаляє 3 старих → Створює 3 нових → Повторює
- Кількість подів: 7-10 (ніколи не перевищує 10)
- Швидкість: Помірна
- Доступність: Мінімум 7/10 подів (70%)

**Переваги:**
- Не потребує додаткових ресурсів
- Ніколи не перевищує бажану кількість реплік
- Економія ресурсів кластера

**Недоліки:**
- Знижена доступність під час оновлення
- Ризик перевантаження (7 подів замість 10)

---

### 4.5. Recreate стратегія (app-deployment-recreate.yaml)

```yaml
strategy:
  type: Recreate
```

**Тестування:**
```bash
kubectl delete deployment course-app -n dtimchuk-dev
kubectl apply -f app-deployment-recreate.yaml
kubectl set env deployment/course-app APP_VERSION="5.0" -n dtimchuk-dev
kubectl rollout status deployment course-app -n dtimchuk-dev

kubectl get pods -n dtimchuk-dev -w
```

**Спостереження:**
- Процес: Видаляє ВСІ 10 подів → Створює 10 нових
- Кількість подів: 10 → 0 → 10
- Швидкість: Залежить від часу старту
- Доступність: 0% під час оновлення

**Переваги:**
- Простота
- Гарантія що старі і нові версії не працюють одночасно
- Корисно для застосунків що не підтримують паралельну роботу версій
- Немає додаткового навантаження на ресурси

**Недоліки:**
- Повний downtime
- Неприйнятно для production застосунків з вимогами до доступності
- Користувачі не можуть користуватись сервісом під час оновлення

**Коли використовувати:**
- Застосунки що не підтримують rolling updates
- База даних з міграціями що несумісні з попередньою версією
- Development/testing середовища
- Застосунки з вимогою однієї версії (state consistency)

---

## Порівняльна таблиця стратегій

| Стратегія    | maxUnavailable | maxSurge | Швидкість | Доступність       | Ресурси     | Використання                      |
|--------------|----------------|----------|-----------|-------------------|-------------|-----------------------------------|
| **Default**  | 1 | 1 | Помірна | Висока (90%)      | 9-11 pods   | Production (баланс)               |
| **Fast**     | 5 | 5 | Дуже швидка | Середня (50%)     | 5-15 pods  | Швидкі оновлення, великі кластери |
| **Slow**     | 0 | 2 | Повільна | Максимальна (100%) | 10-12 pods | Critical production               |
| **No-surge** | 3 | 0 | Помірна | Середня (70%)     | 7-10 pods  | Обмежені ресурси                  |
| **Recreate** | N/A | N/A | Залежить | Downtime          | 0-10 pods  | Для розробки?                     |

---

## Ключові відмінності між стратегіями

### RollingUpdate vs Recreate

**RollingUpdate:**
- Поступове оновлення
- Нові і старі поди працюють паралельно
- Немає downtime
- Складніша конфігурація
- Потребує версіонування API (backward compatibility)

**Recreate:**
- Миттєва заміна всіх подів
- Тільки одна версія працює в будь-який момент
- Гарантований downtime
- Проста конфігурація
- Не потребує backward compatibility

### maxUnavailable vs maxSurge

**maxUnavailable:**
- Скільки подів можна видалити під час оновлення
- Впливає на доступність сервісу
- `0` = максимальна доступність
- Велике значення = швидше оновлення, нижча доступність

**maxSurge:**
- Скільки додаткових подів можна створити
- Впливає на споживання ресурсів
- `0` = немає додаткових ресурсів
- Велике значення = швидше оновлення, більше ресурсів

